### PR TITLE
fix compilation error with literal newline (#5)

### DIFF
--- a/chrome-session-dump.go
+++ b/chrome-session-dump.go
@@ -509,12 +509,11 @@ func main() {
 	flag.BoolVar(&historyFlag, "history", false, "Include the history of each tab in the output.")
 
 	flag.Usage = func() {
-		fmt.Printf("Usage: 
-			   -session-dump [options] ([session file] | [chrome dir])\n\n")
+		fmt.Printf("Usage: chrome-session-dump [options] ([session file] | [chrome dir])\n\n");
 		fmt.Printf(`If a chrome directory is supplied the most recent session file
-contained within it is used. If neither a directory or file 
-is supplied then the program will use ~/.config/chrome by 
-default
+contained within it is used. If neither a directory or file
+is supplied then the program will use ~/.config/chrome by
+default.
 
 `)
 


### PR DESCRIPTION
Literal newlines need to be inside backticks not double quotes.

Fixes #5.